### PR TITLE
In consistent docker image names related to the hash in the tag (vibe-kanban)

### DIFF
--- a/itk_wasm_env.bash
+++ b/itk_wasm_env.bash
@@ -10,7 +10,7 @@ if test "$OSTYPE" = "cygwin" || test "$OSTYPE" = "msys" || test "$OSTYPE" = "win
     export CXXFLAGS="/Zc:__cplusplus /Zc:preprocessor /DNOMINMAX"
 fi
 
-export ITK_WASM_DEV_DOCKER_TAG=${ITK_WASM_DEV_DOCKER_TAG:-$(echo $(date '+%Y%m%d')-$(git rev-parse --short HEAD))}
+export ITK_WASM_DEV_DOCKER_TAG=${ITK_WASM_DEV_DOCKER_TAG:-$(echo $(date '+%Y%m%d')-$(git rev-parse --short=9 HEAD))}
 
 export ITK_WASM_DCMTK_REPOSITORY=${ITK_WASM_DCMTK_REPOSITORY:-"https://github.com/InsightSoftwareConsortium/DCMTK"}
 # 20240311_DCMTK_PATCHES_FOR_ITK-wasm-3

--- a/src/docker/RELEASE.md
+++ b/src/docker/RELEASE.md
@@ -18,7 +18,7 @@ pixi run build-docker-images --with-debug
 pnpm clean && pnpm install && pnpm build && pnpm test
 
 git add -- packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
-git commit -m "feat(itk-wasm-cli): update default Docker image for $(date '+%Y%m%d')-$(git rev-parse --short HEAD)"
+git commit -m "feat(itk-wasm-cli): update default Docker image for $(date '+%Y%m%d')-$(git rev-parse --short=9 HEAD)"
 ```
 
 ## Building with a Local ITK Repository

--- a/src/docker/itk-wasm-base/build.sh
+++ b/src/docker/itk-wasm-base/build.sh
@@ -6,8 +6,8 @@ script_dir="`cd $(dirname $0); pwd`"
 source "$script_dir/../oci_exe.sh"
 exe=$(ociExe)
 
-TAG=$(date '+%Y%m%d')-$(git rev-parse --short HEAD)
-VCS_REF=$(git rev-parse --short HEAD)
+TAG=$(date '+%Y%m%d')-$(git rev-parse --short=9 HEAD)
+VCS_REF=$(git rev-parse --short=9 HEAD)
 VCS_URL="https://github.com/InsightSoftwareConsortium/ITK-Wasm"
 BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 

--- a/src/docker/itk-wasm/build.sh
+++ b/src/docker/itk-wasm/build.sh
@@ -16,8 +16,8 @@ $cp_exe -a ../../../src/emscripten-module ./ITKWebAssemblyInterfaceModuleCopy/sr
 mkdir -p median-filter-pipelineCopy
 $cp_exe -a ../../../packages/core/typescript/itk-wasm/test/pipelines/median-filter-pipeline/{CMakeLists.txt,median-filter-test.cxx} ./median-filter-pipelineCopy
 
-TAG=$(date '+%Y%m%d')-$(git rev-parse --short HEAD)
-VCS_REF=$(git rev-parse --short HEAD)
+TAG=$(date '+%Y%m%d')-$(git rev-parse --short=9 HEAD)
+VCS_REF=$(git rev-parse --short=9 HEAD)
 VCS_URL="https://github.com/InsightSoftwareConsortium/ITK-Wasm"
 BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 

--- a/src/docker/push.sh
+++ b/src/docker/push.sh
@@ -19,7 +19,7 @@ for param; do
 done
 set -- "${newparams[@]}"  # overwrites the original positional params
 
-TAG=$(date '+%Y%m%d')-$(git rev-parse --short HEAD)
+TAG=$(date '+%Y%m%d')-$(git rev-parse --short=9 HEAD)
 host_arch=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 other_arch=$(if [ "$host_arch" == "amd64" ]; then echo "arm64"; else echo "amd64"; fi)
 


### PR DESCRIPTION
When building on my ARM mac, I get images with the tag:

  quay.io/itkwasm/wasi:20260213-2a34266f8-arm64

When referenced on my AMD64 Linux system in the manifest image push, it is looking for:

  quay.io/itkwasm/wasi:20260213-2a34266f-arm64

Why the inconsistency in the tag? Note that the dash have one more character in the forms vs the latter? Can we fix it so it consistency has the same number of characters?